### PR TITLE
feat: YSL-13 RootExceptionHandler 및 Problem 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    implementation("org.zalando:problem-spring-web-starter:0.27.0")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     implementation("org.zalando:problem-spring-web-starter:0.27.0")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
 
     //flyway
     implementation("org.flywaydb:flyway-core")
@@ -42,11 +45,11 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    developmentOnly("org.springframework.boot:spring-boot-devtools")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-
+    //problem
     implementation("org.zalando:problem-spring-web-starter:0.27.0")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    //test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/org/idiot/yesslave/global/exception/InvalidResponse.java
+++ b/src/main/java/org/idiot/yesslave/global/exception/InvalidResponse.java
@@ -3,19 +3,17 @@ package org.idiot.yesslave.global.exception;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 @AllArgsConstructor
-@Schema(description = "유효성 검사에 실패했을 경우의 RESPONSE")
+@Schema(description = "입력된 값에 대한 유효성 검사에 실패했을 경우의 응답값")
 public class InvalidResponse {
-    @Schema(description = "오류 발생 field명", example = "mobileNo")
-    String field;
+    @Schema(description = "오류가 발생한 field명", example = "verificationCode")
+    private String field;
 
-    @Schema(description = "오류 발생 field명", example = "휴대전화번호을 입력해주세요.")
-    String message;
+    @Schema(description = "오류 메세지", example = "확인번호를 입력해주세요.")
+    private String message;
 
-    @Schema(description = "오류 발생 field 입력 값", example = "AAA")
-    Object rejectValue;
+    @Schema(description = "잘못 입력된 field 입력 값", example = "ABCDE")
+    private Object rejectValue;
 }

--- a/src/main/java/org/idiot/yesslave/global/exception/InvalidResponse.java
+++ b/src/main/java/org/idiot/yesslave/global/exception/InvalidResponse.java
@@ -1,0 +1,21 @@
+package org.idiot.yesslave.global.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@Schema(description = "유효성 검사에 실패했을 경우의 RESPONSE")
+public class InvalidResponse {
+    @Schema(description = "오류 발생 field명", example = "mobileNo")
+    String field;
+
+    @Schema(description = "오류 발생 field명", example = "휴대전화번호을 입력해주세요.")
+    String message;
+
+    @Schema(description = "오류 발생 field 입력 값", example = "AAA")
+    Object rejectValue;
+}

--- a/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
+++ b/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
@@ -1,0 +1,40 @@
+package org.idiot.yesslave.global.exception;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.zalando.problem.Problem;
+import org.zalando.problem.spring.web.advice.ProblemHandling;
+
+import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@ControllerAdvice
+//@EnableAutoConfiguration(exclude = ErrorMvcAutoConfiguration.class)
+public class RootExceptionHandler implements ProblemHandling {
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    @ApiResponse(responseCode = "500", description = "Internal Server Error", content = {
+            @Content(schema = @Schema(implementation = Problem.class))
+    })
+    public ResponseEntity<Problem> exceptionHandler(Exception e) {
+
+        log.error("[ 500 ERROR ] : ", e);
+
+        Problem problem = Problem.builder()
+                .withStatus(INTERNAL_SERVER_ERROR)
+                .withTitle(INTERNAL_SERVER_ERROR.getReasonPhrase())
+                .withDetail(e.getMessage())
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(problem);
+    }
+}

--- a/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
+++ b/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
@@ -14,13 +14,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
 
 import javax.validation.ConstraintViolationException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.zalando.problem.Status.BAD_REQUEST;
-import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @ControllerAdvice
@@ -36,8 +34,8 @@ public class RootExceptionHandler {
         log.error("[ 500 ERROR ] : ", e);
 
         Problem problem = Problem.builder()
-                .withStatus(INTERNAL_SERVER_ERROR)
-                .withTitle(INTERNAL_SERVER_ERROR.getReasonPhrase())
+                .withStatus(Status.INTERNAL_SERVER_ERROR)
+                .withTitle(Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
                 .withDetail(e.getMessage())
                 .build();
 
@@ -63,8 +61,8 @@ public class RootExceptionHandler {
         });
 
         Problem problem = Problem.builder()
-                .withStatus(BAD_REQUEST)
-                .withTitle(BAD_REQUEST.getReasonPhrase())
+                .withStatus(Status.BAD_REQUEST)
+                .withTitle(Status.BAD_REQUEST.getReasonPhrase())
                 .with("parameters", responses)
                 .build();
 
@@ -88,8 +86,8 @@ public class RootExceptionHandler {
         });
 
         return Problem.builder()
-                .withStatus(BAD_REQUEST)
-                .withTitle(BAD_REQUEST.getReasonPhrase())
+                .withStatus(Status.BAD_REQUEST)
+                .withTitle(Status.BAD_REQUEST.getReasonPhrase())
                 .with("parameters", responses)
                 .build();
     }

--- a/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
+++ b/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
@@ -17,7 +17,6 @@ import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 
 import javax.validation.ConstraintViolationException;
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -54,11 +53,11 @@ public class RootExceptionHandler {
 
         BindingResult bindingResult = e.getBindingResult();
 
-        List<InvalidResponse> responses = new ArrayList<>();
-
-        bindingResult.getFieldErrors().forEach(fieldError -> {
-            responses.add(new InvalidResponse(fieldError.getField(), fieldError.getDefaultMessage(), fieldError.getRejectedValue()));
-        });
+        List<InvalidResponse> responses = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> new InvalidResponse(fieldError.getField()
+                        , fieldError.getDefaultMessage()
+                        , fieldError.getRejectedValue())
+                ).toList();
 
         Problem problem = Problem.builder()
                 .withStatus(Status.BAD_REQUEST)
@@ -79,11 +78,11 @@ public class RootExceptionHandler {
     public Problem constraintViolationExceptionHandler(ConstraintViolationException e) {
         log.error("[ 400 ERROR ] : ", e);
 
-        List<InvalidResponse> responses = new ArrayList<>();
-
-        e.getConstraintViolations().forEach(fieldError -> {
-            responses.add(new InvalidResponse(fieldError.getPropertyPath().toString(), fieldError.getMessage(), fieldError.getInvalidValue()));
-        });
+        List<InvalidResponse> responses = e.getConstraintViolations().stream()
+                .map(fieldError -> new InvalidResponse(fieldError.getPropertyPath().toString()
+                        , fieldError.getMessage()
+                        , fieldError.getInvalidValue())
+                ).toList();
 
         return Problem.builder()
                 .withStatus(Status.BAD_REQUEST)

--- a/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
+++ b/src/main/java/org/idiot/yesslave/global/exception/RootExceptionHandler.java
@@ -4,20 +4,28 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.zalando.problem.Problem;
-import org.zalando.problem.spring.web.advice.ProblemHandling;
 
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.zalando.problem.Status.BAD_REQUEST;
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @ControllerAdvice
-//@EnableAutoConfiguration(exclude = ErrorMvcAutoConfiguration.class)
-public class RootExceptionHandler implements ProblemHandling {
+@EnableAutoConfiguration(exclude = ErrorMvcAutoConfiguration.class)
+public class RootExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
     @ApiResponse(responseCode = "500", description = "Internal Server Error", content = {
@@ -36,5 +44,53 @@ public class RootExceptionHandler implements ProblemHandling {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(problem);
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ApiResponse(responseCode = "400", description = "Bad Request", content = {
+            @Content(schema = @Schema(implementation = InvalidResponse.class))
+    })
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Problem> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+        log.error("[ 400 ERROR ] : ", e);
+
+        BindingResult bindingResult = e.getBindingResult();
+
+        List<InvalidResponse> responses = new ArrayList<>();
+
+        bindingResult.getFieldErrors().forEach(fieldError -> {
+            responses.add(new InvalidResponse(fieldError.getField(), fieldError.getDefaultMessage(), fieldError.getRejectedValue()));
+        });
+
+        Problem problem = Problem.builder()
+                .withStatus(BAD_REQUEST)
+                .withTitle(BAD_REQUEST.getReasonPhrase())
+                .with("parameters", responses)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(problem);
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ApiResponse(responseCode = "400", description = "Bad Request", content = {
+            @Content(schema = @Schema(implementation = InvalidResponse.class))
+    })
+    @ExceptionHandler(ConstraintViolationException.class)
+    public Problem constraintViolationExceptionHandler(ConstraintViolationException e) {
+        log.error("[ 400 ERROR ] : ", e);
+
+        List<InvalidResponse> responses = new ArrayList<>();
+
+        e.getConstraintViolations().forEach(fieldError -> {
+            responses.add(new InvalidResponse(fieldError.getPropertyPath().toString(), fieldError.getMessage(), fieldError.getInvalidValue()));
+        });
+
+        return Problem.builder()
+                .withStatus(BAD_REQUEST)
+                .withTitle(BAD_REQUEST.getReasonPhrase())
+                .with("parameters", responses)
+                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,4 @@ spring:
       add-mappings: false
   mvc:
     throw-exception-if-no-handler-found: true
+    

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,8 @@ spring:
         format_sql: true
         show_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+  web:
+    resources:
+      add-mappings: false
+  mvc:
+    throw-exception-if-no-handler-found: true


### PR DESCRIPTION
RootExceptionHandler를 도입하였습니다.
실패에 대한 RFC-7807 규약에 맞춰 응답을 제공하기 위해 Problem을 도입해 보았습니다.
기본적인 500, 400 내용만 추가 하였고, 필요하실 때 추가적으로 덧붙여 사용하면 될 것 같습니다.